### PR TITLE
Centralize Trello credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,15 @@ A Model Context Protocol (MCP) server that provides comprehensive Trello integra
        }
      }
    }
-   ```
+```
 
 6. **Restart Claude Desktop**
+
+### Credential handling
+
+- Every tool now reads credentials through environment variables (`TRELLO_API_KEY` / `TRELLO_TOKEN`) so you never need to pass them manually when calling a tool from Claude.
+- If you call the MCP server outside of Claude (e.g., direct HTTP requests), you can still override the credentials per request by supplying `apiKey` and `token`, but they’re optional and only needed when you want to use a different Trello account.
+- The server validates credentials on each call, so misconfigured environment variables still surface clean errors that explain what’s missing.
 
 ## Available Tools
 

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -1,12 +1,10 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { TrelloClient } from '../trello/client.js';
-import { formatValidationError } from '../utils/validation.js';
+import { formatValidationError, extractCredentials } from '../utils/validation.js';
 
 const validateGetBoardCards = (args: unknown) => {
   const schema = z.object({
-    apiKey: z.string().min(1, 'API key is required'),
-    token: z.string().min(1, 'Token is required'),
     boardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid board ID format'),
     attachments: z.string().optional(),
     members: z.string().optional(),
@@ -18,8 +16,6 @@ const validateGetBoardCards = (args: unknown) => {
 
 const validateGetCardActions = (args: unknown) => {
   const schema = z.object({
-    apiKey: z.string().min(1, 'API key is required'),
-    token: z.string().min(1, 'Token is required'),
     cardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid card ID format'),
     filter: z.string().optional(),
     limit: z.number().min(1).max(1000).optional()
@@ -30,8 +26,6 @@ const validateGetCardActions = (args: unknown) => {
 
 const validateGetCardAttachments = (args: unknown) => {
   const schema = z.object({
-    apiKey: z.string().min(1, 'API key is required'),
-    token: z.string().min(1, 'Token is required'),
     cardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid card ID format'),
     fields: z.array(z.string()).optional()
   });
@@ -41,8 +35,6 @@ const validateGetCardAttachments = (args: unknown) => {
 
 const validateGetCardChecklists = (args: unknown) => {
   const schema = z.object({
-    apiKey: z.string().min(1, 'API key is required'),
-    token: z.string().min(1, 'Token is required'),
     cardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid card ID format'),
     checkItems: z.string().optional(),
     fields: z.array(z.string()).optional()
@@ -53,8 +45,6 @@ const validateGetCardChecklists = (args: unknown) => {
 
 const validateGetBoardMembers = (args: unknown) => {
   const schema = z.object({
-    apiKey: z.string().min(1, 'API key is required'),
-    token: z.string().min(1, 'Token is required'),
     boardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid board ID format')
   });
   
@@ -63,8 +53,6 @@ const validateGetBoardMembers = (args: unknown) => {
 
 const validateGetBoardLabels = (args: unknown) => {
   const schema = z.object({
-    apiKey: z.string().min(1, 'API key is required'),
-    token: z.string().min(1, 'Token is required'),
     boardId: z.string().regex(/^[a-f0-9]{24}$/, 'Invalid board ID format')
   });
   
@@ -77,14 +65,6 @@ export const trelloGetBoardCardsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       boardId: {
         type: 'string',
         description: 'ID of the board to get cards from (you can get this from list_boards)',
@@ -109,14 +89,15 @@ export const trelloGetBoardCardsTool: Tool = {
         default: 'open'
       }
     },
-    required: ['apiKey', 'token', 'boardId']
+    required: ['boardId']
   }
 };
 
 export async function handleTrelloGetBoardCards(args: unknown) {
   try {
-    const { apiKey, token, boardId, attachments, members, filter } = validateGetBoardCards(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { boardId, attachments, members, filter } = validateGetBoardCards(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getBoardCards(boardId, {
       ...(attachments && { attachments }),
@@ -193,14 +174,6 @@ export const trelloGetCardActionsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       cardId: {
         type: 'string',
         description: 'ID of the card to get actions for',
@@ -220,14 +193,15 @@ export const trelloGetCardActionsTool: Tool = {
         default: 50
       }
     },
-    required: ['apiKey', 'token', 'cardId']
+    required: ['cardId']
   }
 };
 
 export async function handleTrelloGetCardActions(args: unknown) {
   try {
-    const { apiKey, token, cardId, filter, limit } = validateGetCardActions(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { cardId, filter, limit } = validateGetCardActions(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getCardActions(cardId, {
       ...(filter && { filter }),
@@ -296,14 +270,6 @@ export const trelloGetCardAttachmentsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       cardId: {
         type: 'string',
         description: 'ID of the card to get attachments for',
@@ -315,14 +281,15 @@ export const trelloGetCardAttachmentsTool: Tool = {
         description: 'Optional: specific fields to include (e.g., ["name", "url", "mimeType", "date"])'
       }
     },
-    required: ['apiKey', 'token', 'cardId']
+    required: ['cardId']
   }
 };
 
 export async function handleTrelloGetCardAttachments(args: unknown) {
   try {
-    const { apiKey, token, cardId, fields } = validateGetCardAttachments(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { cardId, fields } = validateGetCardAttachments(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getCardAttachments(cardId, {
       ...(fields && { fields })
@@ -383,14 +350,6 @@ export const trelloGetCardChecklistsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       cardId: {
         type: 'string',
         description: 'ID of the card to get checklists for',
@@ -408,14 +367,15 @@ export const trelloGetCardChecklistsTool: Tool = {
         description: 'Optional: specific fields to include (e.g., ["name", "pos"])'
       }
     },
-    required: ['apiKey', 'token', 'cardId']
+    required: ['cardId']
   }
 };
 
 export async function handleTrelloGetCardChecklists(args: unknown) {
   try {
-    const { apiKey, token, cardId, checkItems, fields } = validateGetCardChecklists(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { cardId, checkItems, fields } = validateGetCardChecklists(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getCardChecklists(cardId, {
       ...(checkItems && { checkItems }),
@@ -475,28 +435,21 @@ export const trelloGetBoardMembersTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       boardId: {
         type: 'string',
         description: 'ID of the board to get members for',
         pattern: '^[a-f0-9]{24}$'
       }
     },
-    required: ['apiKey', 'token', 'boardId']
+    required: ['boardId']
   }
 };
 
 export async function handleTrelloGetBoardMembers(args: unknown) {
   try {
-    const { apiKey, token, boardId } = validateGetBoardMembers(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { boardId } = validateGetBoardMembers(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getBoardMembers(boardId);
     const members = response.data;
@@ -549,28 +502,21 @@ export const trelloGetBoardLabelsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       boardId: {
         type: 'string',
         description: 'ID of the board to get labels for',
         pattern: '^[a-f0-9]{24}$'
       }
     },
-    required: ['apiKey', 'token', 'boardId']
+    required: ['boardId']
   }
 };
 
 export async function handleTrelloGetBoardLabels(args: unknown) {
   try {
-    const { apiKey, token, boardId } = validateGetBoardLabels(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { boardId } = validateGetBoardLabels(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getBoardLabels(boardId);
     const labels = response.data;

--- a/src/tools/boards.ts
+++ b/src/tools/boards.ts
@@ -5,7 +5,8 @@ import {
   validateListBoards, 
   validateGetBoard, 
   validateGetBoardLists, 
-  formatValidationError 
+  formatValidationError,
+  extractCredentials
 } from '../utils/validation.js';
 
 export const listBoardsTool: Tool = {
@@ -14,29 +15,21 @@ export const listBoardsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       filter: {
         type: 'string',
         enum: ['all', 'open', 'closed'],
         description: 'Filter boards by status: "open" for active boards, "closed" for archived boards, "all" for both',
         default: 'open'
       }
-    },
-    required: ['apiKey', 'token']
+    }
   }
 };
 
 export async function handleListBoards(args: unknown) {
   try {
-    const { apiKey, token, filter } = validateListBoards(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { filter } = validateListBoards(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getMyBoards(filter);
     const boards = response.data;
@@ -88,14 +81,6 @@ export const getBoardDetailsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       boardId: {
         type: 'string',
         description: 'The ID of the board to retrieve (you can get this from list_boards)',
@@ -107,14 +92,15 @@ export const getBoardDetailsTool: Tool = {
         default: false
       }
     },
-    required: ['apiKey', 'token', 'boardId']
+    required: ['boardId']
   }
 };
 
 export async function handleGetBoardDetails(args: unknown) {
   try {
-    const { apiKey, token, boardId, includeDetails } = validateGetBoard(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { boardId, includeDetails } = validateGetBoard(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getBoard(boardId, includeDetails);
     const board = response.data;
@@ -189,14 +175,6 @@ export const getListsTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       boardId: {
         type: 'string',
         description: 'The ID of the board to get lists from (you can get this from list_boards)',
@@ -209,14 +187,15 @@ export const getListsTool: Tool = {
         default: 'open'
       }
     },
-    required: ['apiKey', 'token', 'boardId']
+    required: ['boardId']
   }
 };
 
 export async function handleGetLists(args: unknown) {
   try {
-    const { apiKey, token, boardId, filter } = validateGetBoardLists(args);
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { boardId, filter } = validateGetBoardLists(params);
+    const client = new TrelloClient(credentials);
     
     const response = await client.getBoardLists(boardId, filter);
     const lists = response.data;

--- a/src/tools/cards.ts
+++ b/src/tools/cards.ts
@@ -6,7 +6,8 @@ import {
   validateUpdateCard, 
   validateMoveCard, 
   validateGetCard,
-  formatValidationError 
+  formatValidationError,
+  extractCredentials
 } from '../utils/validation.js';
 
 export const createCardTool: Tool = {
@@ -15,14 +16,6 @@ export const createCardTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       name: {
         type: 'string',
         description: 'Name/title of the card (what the task or item is about)'
@@ -65,17 +58,16 @@ export const createCardTool: Tool = {
         description: 'Optional array of label IDs to categorize the card'
       }
     },
-    required: ['apiKey', 'token', 'name', 'idList']
+    required: ['name', 'idList']
   }
 };
 
 export async function handleCreateCard(args: unknown) {
   try {
-    const cardData = validateCreateCard(args);
-    const { apiKey, token, ...createData } = cardData;
-    
-    const client = new TrelloClient({ apiKey, token });
-    const response = await client.createCard(createData);
+    const { credentials, params } = extractCredentials(args);
+    const cardData = validateCreateCard(params);
+    const client = new TrelloClient(credentials);
+    const response = await client.createCard(cardData);
     const card = response.data;
     
     const result = {
@@ -137,14 +129,6 @@ export const updateCardTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       cardId: {
         type: 'string',
         description: 'ID of the card to update (you can get this from board details or card searches)',
@@ -184,16 +168,15 @@ export const updateCardTool: Tool = {
         description: 'Change position in the list: "top", "bottom", or specific number'
       }
     },
-    required: ['apiKey', 'token', 'cardId']
+    required: ['cardId']
   }
 };
 
 export async function handleUpdateCard(args: unknown) {
   try {
-    const updateData = validateUpdateCard(args);
-    const { apiKey, token, cardId, ...updates } = updateData;
-    
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { cardId, ...updates } = validateUpdateCard(params);
+    const client = new TrelloClient(credentials);
     const response = await client.updateCard(cardId, updates);
     const card = response.data;
     
@@ -252,14 +235,6 @@ export const moveCardTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       cardId: {
         type: 'string',
         description: 'ID of the card to move (you can get this from board details or card searches)',
@@ -278,16 +253,15 @@ export const moveCardTool: Tool = {
         description: 'Position in the destination list: "top", "bottom", or specific number'
       }
     },
-    required: ['apiKey', 'token', 'cardId', 'idList']
+    required: ['cardId', 'idList']
   }
 };
 
 export async function handleMoveCard(args: unknown) {
   try {
-    const moveData = validateMoveCard(args);
-    const { apiKey, token, cardId, ...moveParams } = moveData;
-    
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { cardId, ...moveParams } = validateMoveCard(params);
+    const client = new TrelloClient(credentials);
     const response = await client.moveCard(cardId, moveParams);
     const card = response.data;
     
@@ -337,14 +311,6 @@ export const getCardTool: Tool = {
   inputSchema: {
     type: 'object',
     properties: {
-      apiKey: {
-        type: 'string',
-        description: 'Trello API key (automatically provided by Claude.app from your stored credentials)'
-      },
-      token: {
-        type: 'string',
-        description: 'Trello API token (automatically provided by Claude.app from your stored credentials)'
-      },
       cardId: {
         type: 'string',
         description: 'ID of the card to retrieve (you can get this from board details or searches)',
@@ -356,15 +322,15 @@ export const getCardTool: Tool = {
         default: false
       }
     },
-    required: ['apiKey', 'token', 'cardId']
+    required: ['cardId']
   }
 };
 
 export async function handleGetCard(args: unknown) {
   try {
-    const { apiKey, token, cardId, includeDetails } = validateGetCard(args);
-    
-    const client = new TrelloClient({ apiKey, token });
+    const { credentials, params } = extractCredentials(args);
+    const { cardId, includeDetails } = validateGetCard(params);
+    const client = new TrelloClient(credentials);
     const response = await client.getCard(cardId, includeDetails);
     const card = response.data;
     

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -9,28 +9,20 @@ export const credentialsSchema = z.object({
 });
 
 export const listBoardsSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   filter: z.enum(['all', 'open', 'closed']).optional().default('open')
 });
 
 export const getBoardSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   boardId: trelloIdSchema,
   includeDetails: z.boolean().optional().default(false)
 });
 
 export const getBoardListsSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   boardId: trelloIdSchema,
   filter: z.enum(['all', 'open', 'closed']).optional().default('open')
 });
 
 export const createCardSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   name: z.string().min(1, 'Card name is required').max(16384, 'Card name too long'),
   desc: z.string().max(16384, 'Description too long').optional(),
   idList: trelloIdSchema,
@@ -41,8 +33,6 @@ export const createCardSchema = z.object({
 });
 
 export const updateCardSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   cardId: trelloIdSchema,
   name: z.string().min(1).max(16384).optional(),
   desc: z.string().max(16384).optional(),
@@ -56,25 +46,39 @@ export const updateCardSchema = z.object({
 });
 
 export const moveCardSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   cardId: trelloIdSchema,
   idList: trelloIdSchema,
   pos: z.union([z.number().min(0), z.enum(['top', 'bottom'])]).optional()
 });
 
 export const getCardSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   cardId: trelloIdSchema,
   includeDetails: z.boolean().optional().default(false)
 });
 
 export const deleteCardSchema = z.object({
-  apiKey: z.string().min(1, 'API key is required'),
-  token: z.string().min(1, 'Token is required'),
   cardId: trelloIdSchema
 });
+
+type ArgumentRecord = Record<string, unknown>;
+
+export function extractCredentials(args: unknown) {
+  if (args !== undefined && args !== null && typeof args !== 'object') {
+    throw new Error('Tool arguments must be an object.');
+  }
+
+  const { apiKey: argApiKey, token: argToken, ...rest } = (args as ArgumentRecord) ?? {};
+
+  const credentials = credentialsSchema.parse({
+    apiKey: argApiKey ?? process.env.TRELLO_API_KEY,
+    token: argToken ?? process.env.TRELLO_TOKEN
+  });
+
+  return {
+    credentials,
+    params: rest
+  };
+}
 
 export function validateCredentials(data: unknown) {
   return credentialsSchema.parse(data);

--- a/tests/boards.test.ts
+++ b/tests/boards.test.ts
@@ -30,12 +30,12 @@ describe('Boards Tool', () => {
       expect(result.isError).toBeUndefined();
     });
 
-    test('should handle validation error for missing apiKey', async () => {
-      const args = { token: 'testToken' };
+    test('should handle validation error for invalid filter value', async () => {
+      const args = { apiKey: 'testKey', token: 'testToken', filter: 'invalid' };
       const result = await handleListBoards(args);
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Error listing boards: Validation error: apiKey: Required');
+      expect(result.content[0].text).toContain('Error listing boards: Validation error: filter: Invalid enum value');
     });
 
     test('should handle Trello API error', async () => {

--- a/tests/members.test.ts
+++ b/tests/members.test.ts
@@ -45,12 +45,12 @@ describe('Members Tool', () => {
       expect(result.isError).toBeUndefined();
     });
 
-    test('should handle validation error for missing apiKey', async () => {
-      const args = { token: 'testToken' };
+    test('should handle validation error for invalid filter', async () => {
+      const args = { apiKey: 'testKey', token: 'testToken', filter: 'invalid' };
       const result = await handleTrelloGetUserBoards(args);
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Error getting user boards: Validation error: apiKey: Required');
+      expect(result.content[0].text).toContain('Error getting user boards: Validation error: filter: Invalid enum value');
     });
   });
 

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -45,19 +45,19 @@ describe('validation utilities', () => {
 
   describe('listBoardsSchema and validateListBoards', () => {
     it('should validate correct list boards parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', filter: 'all' };
+      const validParams = { filter: 'all' };
       expect(() => listBoardsSchema.parse(validParams)).not.toThrow();
       expect(validateListBoards(validParams)).toEqual(validParams);
     });
 
     it('should validate list boards parameters with default filter', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken' };
+      const validParams = {};
       expect(() => listBoardsSchema.parse(validParams)).not.toThrow();
-      expect(validateListBoards(validParams)).toEqual({ ...validParams, filter: 'open' });
+      expect(validateListBoards(validParams)).toEqual({ filter: 'open' });
     });
 
     it('should reject list boards parameters with invalid filter', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', filter: 'invalid' };
+      const invalidParams = { filter: 'invalid' };
       expect(() => listBoardsSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateListBoards(invalidParams)).toThrow(ZodError);
     });
@@ -65,19 +65,19 @@ describe('validation utilities', () => {
 
   describe('getBoardSchema and validateGetBoard', () => {
     it('should validate correct get board parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', boardId: '6512e4a208a3061f8a9e5a6a', includeDetails: true };
+      const validParams = { boardId: '6512e4a208a3061f8a9e5a6a', includeDetails: true };
       expect(() => getBoardSchema.parse(validParams)).not.toThrow();
       expect(validateGetBoard(validParams)).toEqual(validParams);
     });
 
     it('should validate get board parameters with default includeDetails', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', boardId: '6512e4a208a3061f8a9e5a6a' };
+      const validParams = { boardId: '6512e4a208a3061f8a9e5a6a' };
       expect(() => getBoardSchema.parse(validParams)).not.toThrow();
       expect(validateGetBoard(validParams)).toEqual({ ...validParams, includeDetails: false });
     });
 
     it('should reject get board parameters with invalid boardId', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', boardId: 'invalid' };
+      const invalidParams = { boardId: 'invalid' };
       expect(() => getBoardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateGetBoard(invalidParams)).toThrow(ZodError);
     });
@@ -85,19 +85,19 @@ describe('validation utilities', () => {
 
   describe('getBoardListsSchema and validateGetBoardLists', () => {
     it('should validate correct get board lists parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', boardId: '6512e4a208a3061f8a9e5a6a', filter: 'closed' };
+      const validParams = { boardId: '6512e4a208a3061f8a9e5a6a', filter: 'closed' };
       expect(() => getBoardListsSchema.parse(validParams)).not.toThrow();
       expect(validateGetBoardLists(validParams)).toEqual(validParams);
     });
 
     it('should validate get board lists parameters with default filter', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', boardId: '6512e4a208a3061f8a9e5a6a' };
+      const validParams = { boardId: '6512e4a208a3061f8a9e5a6a' };
       expect(() => getBoardListsSchema.parse(validParams)).not.toThrow();
       expect(validateGetBoardLists(validParams)).toEqual({ ...validParams, filter: 'open' });
     });
 
     it('should reject get board lists parameters with invalid boardId', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', boardId: 'invalid' };
+      const invalidParams = { boardId: 'invalid' };
       expect(() => getBoardListsSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateGetBoardLists(invalidParams)).toThrow(ZodError);
     });
@@ -105,27 +105,25 @@ describe('validation utilities', () => {
 
   describe('createCardSchema and validateCreateCard', () => {
     it('should validate correct create card parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', name: 'New Card', idList: '6512e4a208a3061f8a9e5a6a' };
+      const validParams = { name: 'New Card', idList: '6512e4a208a3061f8a9e5a6a' };
       expect(() => createCardSchema.parse(validParams)).not.toThrow();
       expect(validateCreateCard(validParams)).toEqual(validParams);
     });
 
     it('should reject create card parameters with missing name', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', idList: '6512e4a208a3061f8a9e5a6a' };
+      const invalidParams = { idList: '6512e4a208a3061f8a9e5a6a' };
       expect(() => createCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateCreateCard(invalidParams)).toThrow(ZodError);
     });
 
     it('should reject create card parameters with invalid idList', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', name: 'New Card', idList: 'invalid' };
+      const invalidParams = { name: 'New Card', idList: 'invalid' };
       expect(() => createCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateCreateCard(invalidParams)).toThrow(ZodError);
     });
 
     it('should validate create card parameters with optional fields', () => {
       const validParams = {
-        apiKey: 'someApiKey',
-        token: 'someToken',
         name: 'New Card',
         desc: 'Description',
         idList: '6512e4a208a3061f8a9e5a6a',
@@ -141,21 +139,19 @@ describe('validation utilities', () => {
 
   describe('updateCardSchema and validateUpdateCard', () => {
     it('should validate correct update card parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', cardId: '6512e4a208a3061f8a9e5a6a', name: 'Updated Card' };
+      const validParams = { cardId: '6512e4a208a3061f8a9e5a6a', name: 'Updated Card' };
       expect(() => updateCardSchema.parse(validParams)).not.toThrow();
       expect(validateUpdateCard(validParams)).toEqual(validParams);
     });
 
     it('should reject update card parameters with invalid cardId', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', cardId: 'invalid' };
+      const invalidParams = { cardId: 'invalid' };
       expect(() => updateCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateUpdateCard(invalidParams)).toThrow(ZodError);
     });
 
     it('should validate update card parameters with optional fields', () => {
       const validParams = {
-        apiKey: 'someApiKey',
-        token: 'someToken',
         cardId: '6512e4a208a3061f8a9e5a6a',
         desc: 'Updated Description',
         closed: true,
@@ -173,19 +169,19 @@ describe('validation utilities', () => {
 
   describe('moveCardSchema and validateMoveCard', () => {
     it('should validate correct move card parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', cardId: '6512e4a208a3061f8a9e5a6a', idList: '6512e4a208a3061f8a9e5a6b' };
+      const validParams = { cardId: '6512e4a208a3061f8a9e5a6a', idList: '6512e4a208a3061f8a9e5a6b' };
       expect(() => moveCardSchema.parse(validParams)).not.toThrow();
       expect(validateMoveCard(validParams)).toEqual(validParams);
     });
 
     it('should reject move card parameters with invalid cardId', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', cardId: 'invalid', idList: '6512e4a208a3061f8a9e5a6b' };
+      const invalidParams = { cardId: 'invalid', idList: '6512e4a208a3061f8a9e5a6b' };
       expect(() => moveCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateMoveCard(invalidParams)).toThrow(ZodError);
     });
 
     it('should reject move card parameters with invalid idList', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', cardId: '6512e4a208a3061f8a9e5a6a', idList: 'invalid' };
+      const invalidParams = { cardId: '6512e4a208a3061f8a9e5a6a', idList: 'invalid' };
       expect(() => moveCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateMoveCard(invalidParams)).toThrow(ZodError);
     });
@@ -193,19 +189,19 @@ describe('validation utilities', () => {
 
   describe('getCardSchema and validateGetCard', () => {
     it('should validate correct get card parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', cardId: '6512e4a208a3061f8a9e5a6a', includeDetails: true };
+      const validParams = { cardId: '6512e4a208a3061f8a9e5a6a', includeDetails: true };
       expect(() => getCardSchema.parse(validParams)).not.toThrow();
       expect(validateGetCard(validParams)).toEqual(validParams);
     });
 
     it('should validate get card parameters with default includeDetails', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', cardId: '6512e4a208a3061f8a9e5a6a' };
+      const validParams = { cardId: '6512e4a208a3061f8a9e5a6a' };
       expect(() => getCardSchema.parse(validParams)).not.toThrow();
       expect(validateGetCard(validParams)).toEqual({ ...validParams, includeDetails: false });
     });
 
     it('should reject get card parameters with invalid cardId', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', cardId: 'invalid' };
+      const invalidParams = { cardId: 'invalid' };
       expect(() => getCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateGetCard(invalidParams)).toThrow(ZodError);
     });
@@ -213,13 +209,13 @@ describe('validation utilities', () => {
 
   describe('deleteCardSchema and validateDeleteCard', () => {
     it('should validate correct delete card parameters', () => {
-      const validParams = { apiKey: 'someApiKey', token: 'someToken', cardId: '6512e4a208a3061f8a9e5a6a' };
+      const validParams = { cardId: '6512e4a208a3061f8a9e5a6a' };
       expect(() => deleteCardSchema.parse(validParams)).not.toThrow();
       expect(validateDeleteCard(validParams)).toEqual(validParams);
     });
 
     it('should reject delete card parameters with invalid cardId', () => {
-      const invalidParams = { apiKey: 'someApiKey', token: 'someToken', cardId: 'invalid' };
+      const invalidParams = { cardId: 'invalid' };
       expect(() => deleteCardSchema.parse(invalidParams)).toThrow(ZodError);
       expect(() => validateDeleteCard(invalidParams)).toThrow(ZodError);
     });


### PR DESCRIPTION
## Summary
- add extractCredentials helper so MCP tools stop requesting apiKey/token parameters
- simplify schemas + handlers to use shared credentials + document the change
- adjust tests to reflect new validation paths

## Testing
- npm test -- --runInBand